### PR TITLE
Fixes typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from the cloud, and processes it as usual.
 1. on your B2DROP server go to the <nextcloud>/apps directory
 2. git clone this repository using
 
-   ```git clone https://github.com/clarin-eric/B2Drop2LRSwitchboard.git lrsswitchboardbridge ```
+   ```git clone https://github.com/clarin-eric/B2Drop2LRSwitchboard.git lrswitchboardbridge ```
 
 3. enable the app on the B2DROP/nextcloud web interface
 


### PR DESCRIPTION
Fixes typo in git clone statement. The erroneous statement will result in an error while activating the app, as NC cannot find it.